### PR TITLE
Add variation selector to reactions

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -25,6 +25,7 @@ post_template = """
 """ .format(user_template=user_template)
 
 MAGIC_EMOJI = '\u2b55'
+VARIATION_SELECTOR_16 = '\ufe0f'
 
 TWIM_REGEX = "^TWIM(?:[:\s]|$)"
 
@@ -185,7 +186,7 @@ async def twim_bot(opsdroid, config, message):
     await message.respond(events.Message(random.choice(responses)))
 
     try:
-        await message.respond(events.Reaction(MAGIC_EMOJI))
+        await message.respond(events.Reaction(MAGIC_EMOJI + VARIATION_SELECTOR_16))
     except MatrixException:
         _LOGGER.error("Failed to react to submission with magic emoji.")
         pass


### PR DESCRIPTION
[MSC2677](https://github.com/matrix-org/matrix-doc/pull/2677) says

> When sending emoji reactions, the `key` field should include the colourful variation-16 when applicable.

---

Doesn't change the MAGIC_EMOJI variable so that clients sending the wrong (variation-selector-less) emoji will still be accepted